### PR TITLE
Don’t output stack trace unless --verbose is passed. Support option for --disable-owl-nothing.

### DIFF
--- a/src/main/scala/org/renci/relationgraph/Config.scala
+++ b/src/main/scala/org/renci/relationgraph/Config.scala
@@ -11,9 +11,9 @@ final case class Config(ontologyFile: String,
                         propertiesFile: Option[String],
                         outputSubclasses: BoolValue = FalseValue,
                         reflexiveSubclasses: BoolValue = TrueValue,
-                        equivalenceAsSubclass: BoolValue = TrueValue) {
-
-}
+                        equivalenceAsSubclass: BoolValue = TrueValue,
+                        disableOwlNothing: BoolValue = FalseValue,
+                        verbose: Boolean = false)
 
 object Config {
 


### PR DESCRIPTION
Fixes #101.